### PR TITLE
dont drop first value of signal when saving to spiffs

### DIFF
--- a/include/spiffsutils.h
+++ b/include/spiffsutils.h
@@ -56,9 +56,10 @@ void storeSPIFFS(const char * path, uint16_t *signal433_store, uint16_t size){
         return;
     }
    int i = 0;
-   while(i++ < size){
+   while(i < size){
        file.write((unsigned char)(signal433_store[i]>>8 & 0xff));
        file.write((unsigned char)(signal433_store[i] & 0xff));
+       i++;
     }
 }
 


### PR DESCRIPTION
as `i` was incremented in the `while` statement, the loop would start
with `i == 1` and thus not saving the first element of `signal433_store`
to the flash.